### PR TITLE
Update PWM frequency to 32KHz

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,27 @@
 #define PIN_THROTTLE A4
 
 void setup() {
+
+    // Timer0 controls pins 5, 6
+    // Set timer mode to PWM Phase Correct
+    TCCR0A = ((TCCR0A & 0b11111100) | 0x01);
+    // configure complementary pwm on low side
+    TCCR0A = 0b10110000 | (TCCR0A & 0b00001111);
+    // set prescaler to 1 - 32kHz
+    TCCR0B = ((TCCR0B & 0b11110000) | 0x01); 
+
+    // Timer1 controls pins 9, 10
+    // set prescaler to 1 - 32kHz
+    TCCR1B = ((TCCR1B & 0b11110000) | 0x01); 
+    // configure complementary pwm on low side
+    TCCR1A = 0b11100000 | (TCCR1A & 0b00001111);
+
+    // Timer2 controls pins 3, 11
+    // set prescaler to 1 - 32kHz
+    TCCR2B = ((TCCR2B & 0b11110000) | 0x01); 
+    // configure complementary pwm on low side
+    TCCR2A = 0b11100000 | (TCCR2A & 0b00001111);
+
     pinMode(PIN_MOSFET_A_LO, OUTPUT);
     pinMode(PIN_MOSFET_A_HI, OUTPUT);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,21 +22,21 @@ void setup() {
     // Set timer mode to PWM Phase Correct
     TCCR0A = ((TCCR0A & 0b11111100) | 0x01);
     // configure complementary pwm on low side
-    TCCR0A = 0b10110000 | (TCCR0A & 0b00001111);
+    TCCR0A = (TCCR0A & 0b00001111) | 0b10110000;
     // set prescaler to 1 - 32kHz
-    TCCR0B = ((TCCR0B & 0b11110000) | 0x01); 
+    TCCR0B = ((TCCR0B & 0b11110000) | 0x01);
 
     // Timer1 controls pins 9, 10
-    // set prescaler to 1 - 32kHz
-    TCCR1B = ((TCCR1B & 0b11110000) | 0x01); 
     // configure complementary pwm on low side
-    TCCR1A = 0b11100000 | (TCCR1A & 0b00001111);
+    TCCR1A = (TCCR1A & 0b00001111) | 0b11100000;
+    // set prescaler to 1 - 32kHz
+    TCCR1B = ((TCCR1B & 0b11110000) | 0x01);
 
     // Timer2 controls pins 3, 11
-    // set prescaler to 1 - 32kHz
-    TCCR2B = ((TCCR2B & 0b11110000) | 0x01); 
     // configure complementary pwm on low side
-    TCCR2A = 0b11100000 | (TCCR2A & 0b00001111);
+    TCCR2A = (TCCR2A & 0b00001111) | 0b11100000;
+    // set prescaler to 1 - 32kHz
+    TCCR2B = ((TCCR2B & 0b11110000) | 0x01);
 
     pinMode(PIN_MOSFET_A_LO, OUTPUT);
     pinMode(PIN_MOSFET_A_HI, OUTPUT);
@@ -52,7 +52,6 @@ void setup() {
     pinMode(PIN_HALL_C, INPUT_PULLUP);
 
     // Serial.begin(9600);
-
 }
 
 void loop() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,9 @@
 /*  Arduino Motor Controller Firmware */
 #include "Arduino.h"
 
+// This must be set to 0 in order to run motor
+#define HALL_DEBUG_MODE 0
+
 #define PIN_MOSFET_A_LO 11
 #define PIN_MOSFET_A_HI 10
 
@@ -17,24 +20,17 @@
 #define PIN_THROTTLE A4
 
 void setup() {
-
     // Timer0 controls pins 5, 6
     // Set timer mode to PWM Phase Correct
     TCCR0A = ((TCCR0A & 0b11111100) | 0x01);
-    // configure complementary pwm on low side
-    TCCR0A = (TCCR0A & 0b00001111) | 0b10110000;
     // set prescaler to 1 - 32kHz
     TCCR0B = ((TCCR0B & 0b11110000) | 0x01);
 
     // Timer1 controls pins 9, 10
-    // configure complementary pwm on low side
-    TCCR1A = (TCCR1A & 0b00001111) | 0b11100000;
     // set prescaler to 1 - 32kHz
     TCCR1B = ((TCCR1B & 0b11110000) | 0x01);
 
     // Timer2 controls pins 3, 11
-    // configure complementary pwm on low side
-    TCCR2A = (TCCR2A & 0b00001111) | 0b11100000;
     // set prescaler to 1 - 32kHz
     TCCR2B = ((TCCR2B & 0b11110000) | 0x01);
 
@@ -51,29 +47,27 @@ void setup() {
     pinMode(PIN_HALL_B, INPUT_PULLUP);
     pinMode(PIN_HALL_C, INPUT_PULLUP);
 
-    // Serial.begin(9600);
+    if (HALL_DEBUG_MODE) {
+        Serial.begin(9600);
+    }
 }
 
 void loop() {
-    // Reading from potentiometer
-    int throttle = analogRead(PIN_THROTTLE);
-
-    // Serial.println(throttle);
-
-    // Mapping the Values between 0 to 255 because we can give output
-    // from 0 -255 using the analogwrite funtion
-    int dutyCycle = map(throttle, 0, 1023, 0, 255);
-
     bool hallA = digitalRead(PIN_HALL_A);
     bool hallB = digitalRead(PIN_HALL_B);
     bool hallC = digitalRead(PIN_HALL_C);
 
-    // Serial.print("hallA: ");
-    // Serial.print(hallA);
-    // Serial.print(" - hallB: ");
-    // Serial.print(hallB);
-    // Serial.print(" - hallC: ");
-    // Serial.println(hallC);
+    if (HALL_DEBUG_MODE) {
+        Serial.print("hallA: ");
+        Serial.print(hallA);
+        Serial.print(" - hallB: ");
+        Serial.print(hallB);
+        Serial.print(" - hallC: ");
+        Serial.println(hallC);
+    }
+
+    // Reading from potentiometer
+    int dutyCycle = analogRead(PIN_THROTTLE) / 4;
 
     if (hallA && !hallB && hallC) {
         analogWrite(PIN_MOSFET_A_LO, 0);


### PR DESCRIPTION
This is mostly copied from here: https://github.com/simplefoc/Arduino-FOC/blob/master/src/drivers/hardware_specific/atmega/atmega328_mcu.cpp#L158

Updates AVR timers and PWM prescalers to provide 32KHz for all 6 PWM channels. This will break delay() and millis() functions, as they rely on the timers to be a specific frequency. 

Note that I'm not 100% sure that this works, so it should not be merged until we can test the PWM output with an oscilloscope. 